### PR TITLE
options.unscope

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -669,15 +669,15 @@ DataAccessObject.replaceOrCreate = function replaceOrCreate(data, options, cb) {
   if (id === undefined || id === null) {
     return this.create(data, options, cb);
   }
-  
+
   var inst;
   if (data instanceof Model) {
     inst = data;
   } else {
     inst = new Model(data);
   }
-  
-  var strict = inst.__strict; 
+
+  var strict = inst.__strict;
   var context = {
     Model: Model,
     query: byIdQuery(Model, id),
@@ -947,7 +947,9 @@ DataAccessObject.findOrCreate = function findOrCreate(query, data, options, cb) 
       return cb.promise;
     }
 
-    this.applyScope(query);
+    if (!options.unscope) {
+      this.applyScope(query);
+    }
 
     var context = {
       Model: Model,
@@ -1613,7 +1615,9 @@ DataAccessObject.find = function find(query, options, cb) {
     return cb.promise;
   }
 
-  this.applyScope(query);
+  if (!options.unscope) {
+    this.applyScope(query);
+  }
 
   var near = query && geo.nearFilter(query.where);
   var supportsGeo = !!connector.buildNearFilter;
@@ -1872,7 +1876,9 @@ DataAccessObject.remove = DataAccessObject.deleteAll = DataAccessObject.destroyA
   var hookState = {};
 
   var query = { where: where };
-  this.applyScope(query);
+  if (!options.unscope) {
+    this.applyScope(query);
+  }
   where = query.where;
 
   var context = {
@@ -2071,7 +2077,9 @@ DataAccessObject.count = function (where, options, cb) {
   var hookState = {};
 
   var query = { where: where };
-  this.applyScope(query);
+  if (!options.unscope) {
+    this.applyScope(query);
+  }
   where = query.where;
 
   try {
@@ -2322,7 +2330,9 @@ DataAccessObject.updateAll = function (where, data, options, cb) {
   var hookState = {};
 
   var query = { where: where };
-  this.applyScope(query);
+  if (!options.unscope) {
+    this.applyScope(query);
+  }
   this.applyProperties(data);
 
   where = query.where;
@@ -2653,7 +2663,7 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
     process.nextTick(function() { cb(err); });
     return cb.promise;
   }
-  
+
   var context = {
     Model: Model,
     instance: inst,
@@ -2664,7 +2674,7 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
 
   Model.notifyObserversOf('before save', context, function(err, ctx) {
     if (err) return cb(err);
-    
+
     data = inst.toObject(false);
 
     if (strict) {
@@ -2676,7 +2686,7 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
     function validateAndCallConnector(err, data) {
       if (err) return cb(err);
       data = removeUndefined(data);
-      // update instance's properties    
+      // update instance's properties
       inst.setAttributes(data);
 
       var doValidate = true;
@@ -2709,7 +2719,7 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
         copyData(data, inst);
         var typedData = convertSubsetOfPropertiesByType(inst, data);
         context.data = typedData;
-        
+
         function replaceCallback(err, data) {
           if (err) return cb(err);
 
@@ -2753,7 +2763,7 @@ DataAccessObject.replaceById = function(id, data, options, cb) {
         Model.notifyObserversOf('persist', ctx, function(err) {
           connector.replaceById(model, id,
             inst.constructor._forDB(context.data), options, replaceCallback);
-        });        
+        });
       }
     }
   });


### PR DESCRIPTION
```
options: {
  unscope: Boolean | String | [String] 
}

unscope === true, do not apply default scope
typeof unscope === 'string', remove corresponding scope in the query
Array.isArray(unscope), remove corresponding scopes in the query

examples:

defaultScope: {name: 'neil'}

User.find({where: {age: 3, name: 'tester'}}, {unscope: true}, cb);
return  users whose name is tester and age is 3, ignoring default scope.

User.find({where: {age: 3, name: 'tester'}}, {unscope: 'where.name'}, cb)
returns users whose age is 3

User.find({where: {age:3, name: 'tester'}, {unscope: ['where.name', 'where.age']}}, cb)
returns all users
```
